### PR TITLE
The scrollLeft value should be determined by the offset.left of x

### DIFF
--- a/jquery.scrollto.js
+++ b/jquery.scrollto.js
@@ -25,7 +25,7 @@ $.scrollTo = $.fn.scrollTo = function(x, y, options){
     return this.each(function(){
         var elem = $(this);
         elem.stop().animate({
-            scrollLeft: !isNaN(Number(x)) ? x : $(y).offset().left + options.gap.x,
+            scrollLeft: !isNaN(Number(x)) ? x : $(x).offset().left + options.gap.x,
             scrollTop: !isNaN(Number(y)) ? y : $(y).offset().top + options.gap.y
         }, options.animation);
     });


### PR DESCRIPTION
Thanks for this plugin!

I'm assuming it's a typo, but you're using the second element to determine both the scollLeft and scrollTop values. This causes problems when the second argument is a number, or when the two elements provided are different.

If this is intentional, forgive me, and please explain!
