### PR TITLE
Made y argument optional

### DIFF
--- a/jquery.scrollto.js
+++ b/jquery.scrollto.js
@@ -23,6 +23,9 @@
             }
         }, options);
 
+        //This way we can scroll to one element
+        y = y || x;
+
         return this.each(function(){
             var elem = $(this);
             elem.stop().animate({


### PR DESCRIPTION
If `y` isn't provided, it will scroll to `x` element.

Example: `$.scrollTo('#article_12')`

_Maybe a solution making both `x` and `y` optional (scrolling only x or only y axes) would be better_
